### PR TITLE
Improvements on the result/promise APIs

### DIFF
--- a/library-core/src/main/kotlin/com/pusher/util/Result.kt
+++ b/library-core/src/main/kotlin/com/pusher/util/Result.kt
@@ -32,7 +32,16 @@ sealed class Result<A, B> {
         fun <A, B> failure(error: B) = Failure<A, B>(error)
         @JvmStatic
         fun <B> failuresOf(vararg results: Result<*, B>): List<B> =
+            failuresOf(results.asList())
+        @JvmStatic
+        fun <B> failuresOf(results: List<Result<*, B>>): List<B> =
             results.mapNotNull { it as? Result.Failure }.map { it.error }
+        @JvmStatic
+        fun <A> successesOf(vararg results: Result<A, *>): List<A> =
+            successesOf(results.asList())
+        @JvmStatic
+        fun <A> successesOf(results: List<Result<A, *>>): List<A> =
+            results.mapNotNull { it as? Result.Success }.map { it.value }
     }
 
     data class Success<A, B> internal constructor(val value: A) : Result<A, B>()


### PR DESCRIPTION
 - Made `onReady` return the promise to allow for method chaining 
 - Added convenience companion functions for Result that allow extracting successes as well as failures from a list of results.