### PR TITLE
Refer to the actual locator input instead of companion object

### DIFF
--- a/pusher-platform-android/src/test/kotlin/com/pusher/platform/logger/AndroidLoggerTest.kt
+++ b/pusher-platform-android/src/test/kotlin/com/pusher/platform/logger/AndroidLoggerTest.kt
@@ -14,7 +14,7 @@ private val EXPECTED_ERROR = Error("Awesome error")
 
 class AndroidLoggerTest {
 
-    @ParameterizedTest(name = " should log {0}")
+    @ParameterizedTest(name = "should log {0}")
     @EnumSource(LogLevel::class)
     fun shouldLog(logLevel: LogLevel) {
         val doLog: Logger.(String, Error?) -> Unit = logLevel.doLog
@@ -28,7 +28,7 @@ class AndroidLoggerTest {
     }
 
 
-    @ParameterizedTest(name = " should log {0} with Error")
+    @ParameterizedTest(name = "should log {0} with Error")
     @EnumSource(LogLevel::class)
     fun shouldLog_withError(logLevel: LogLevel) {
         val doLog: Logger.(String, Error?) -> Unit = logLevel.doLog
@@ -44,7 +44,7 @@ class AndroidLoggerTest {
     @Nested
     class Threshold {
 
-        @ParameterizedTest(name = " should log {0} when threshold is higher")
+        @ParameterizedTest(name = "should log {0} when threshold is higher")
         @EnumSource(LogLevel::class)
         fun shouldNotLog_whenThresholdIsHigher(logLevel: LogLevel) {
             val log = LogSpy()

--- a/pusher-platform-core/src/main/kotlin/com/pusher/platform/Instance.kt
+++ b/pusher-platform-core/src/main/kotlin/com/pusher/platform/Instance.kt
@@ -172,7 +172,7 @@ private data class Locator(val version: String, val cluster: String, val id: Str
             val splitInstanceLocator = raw.split(":")
             splitInstanceLocator.getOrNull(2)
             require(splitInstanceLocator.size == 3) {
-                "Expecting locator to be of the form 'v1:us1:1a234-123a-1234-12a3-1234123aa12' but got this instead: $raw'. Check the dashboard to ensure you have a properly formatted locator."
+                "Expecting locator to be of the form 'v1:us1:1a234-123a-1234-12a3-1234123aa12' but got this instead: '$raw'. Check the dashboard to ensure you have a properly formatted locator."
             }
             val (version, cluster, id) = splitInstanceLocator
             return Locator(version, cluster, id)

--- a/pusher-platform-core/src/main/kotlin/com/pusher/platform/Instance.kt
+++ b/pusher-platform-core/src/main/kotlin/com/pusher/platform/Instance.kt
@@ -172,7 +172,7 @@ private data class Locator(val version: String, val cluster: String, val id: Str
             val splitInstanceLocator = raw.split(":")
             splitInstanceLocator.getOrNull(2)
             require(splitInstanceLocator.size == 3) {
-                "Expecting locator to be of the form 'v1:us1:1a234-123a-1234-12a3-1234123aa12' but got this instead: $this'. Check the dashboard to ensure you have a properly formatted locator."
+                "Expecting locator to be of the form 'v1:us1:1a234-123a-1234-12a3-1234123aa12' but got this instead: $raw'. Check the dashboard to ensure you have a properly formatted locator."
             }
             val (version, cluster, id) = splitInstanceLocator
             return Locator(version, cluster, id)


### PR DESCRIPTION
The error provided is not useful as it doesn't provide the actual value provided to the factory method.