### PR TITLE
Add option to use external SDK tester

### DIFF
--- a/pusher-platform-core/build.gradle
+++ b/pusher-platform-core/build.gradle
@@ -69,3 +69,10 @@ kotlin {
         coroutines 'enable'
     }
 }
+
+afterEvaluate {
+    // adds properties for tests
+    def junitPlatformTestTask = tasks.getByName('junitPlatformTest')
+    junitPlatformTestTask.systemProperties += rootProject.properties.findAll { it.value instanceof String }
+    junitPlatformTestTask.systemProperties += System.env
+}

--- a/pusher-platform-core/src/integrationTest/kotlin/com/pusher/platform/InstanceSubscribeIntegrationSpek.kt
+++ b/pusher-platform-core/src/integrationTest/kotlin/com/pusher/platform/InstanceSubscribeIntegrationSpek.kt
@@ -19,7 +19,7 @@ private const val PATH_FORBIDDEN = "subscribe_forbidden"
 
 class InstancesubscribeIntegrationSpek : Spek({
 
-    describeWhenReachable("https://${HOST}", "Instance Subscribe") {
+    describeWhenReachable("https://$HOST", "Instance Subscribe") {
         val instance = Instance(
             locator = "v1:api-ceres:test",
             serviceName = "platform_sdk_tester",

--- a/pusher-platform-core/src/integrationTest/kotlin/com/pusher/platform/InstanceTestFixtures.kt
+++ b/pusher-platform-core/src/integrationTest/kotlin/com/pusher/platform/InstanceTestFixtures.kt
@@ -5,13 +5,20 @@ import com.pusher.platform.logger.Logger
 import com.pusher.platform.network.ConnectivityHelper
 import com.pusher.platform.test.AlwaysOnlineConnectivityHelper
 import com.pusher.platform.test.AsyncScheduler
+import com.pusher.platform.test.describeWhenReachable
 import com.pusher.platform.test.insecureOkHttpClient
 import mockitox.stub
 import okhttp3.OkHttpClient
 import java.util.logging.Level
 import java.util.logging.Logger.getLogger as findJavaLoggerFor
 
-const val HOST = "localhost:10443"
+/**
+ * If nothing is set up the default location to the sdk tester is assumed to be localhost:10443.
+ * When the property 'pusher_platform_sdk_tester_host' is set in ~/.gradle/gradle.properties or
+ * as an environment variable. In either case, if the path is not reachable, any tests using
+ * [describeWhenReachable] will be skipped.
+ */
+val HOST: String = System.getProperty("pusher_platform_sdk_tester_host", "localhost:10443")
 
 val testHttpClient = BaseClient(
     host = HOST,


### PR DESCRIPTION
The test Specifications will look for the property `pusher_platform_sdk_tester_host` to be used as a test host. i.e. on travis.