### PR TITLE
Handle non-IO exceptions during subscription

### DIFF
--- a/pusher-platform-core/src/main/kotlin/com/pusher/platform/subscription/BaseSubscription.kt
+++ b/pusher-platform-core/src/main/kotlin/com/pusher/platform/subscription/BaseSubscription.kt
@@ -58,6 +58,8 @@ internal class BaseSubscription<A>(
                     e is SSLHandshakeException -> onError(Errors.other(e))
                     else -> onError(NetworkError("Connection failed"))
                 }
+            } catch (e: Exception) {
+                onError(Errors.other(e))
             }
         }
     }


### PR DESCRIPTION
IOExceptions are not the only kind which can be raised while dealing
with the response.

Without catching and forwarding to onError, the upper layers will not be
able to drive re-attempts and the subscription silently dies.